### PR TITLE
Use fastest mirror to download fedora packages

### DIFF
--- a/templates/etc/dnf/dnf.conf.j2
+++ b/templates/etc/dnf/dnf.conf.j2
@@ -2,6 +2,7 @@
 gpgcheck=1
 installonly_limit=3
 clean_requirements_on_remove=true
+fastestmirror=true
 
 {% if proxify_dl_timeout is defined %}
 timeout={{proxify_dl_timeout}}


### PR DESCRIPTION
Bit experimental. Trying to reduce timeout errors that by configuring dnf to use fastest mirror. by default dnf would try most recommended mirror first not the fastest.
